### PR TITLE
Codes to use DM Exposures as inputs

### DIFF
--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -67,8 +67,6 @@ class MultiBandCoadds(object):
         If True, use the stacks interpolation, default False
     interp_bright: bool
         If True, mark BRIGHT as SAT and do interpolation
-    replace_bright: bool
-        If True, replace BRIGHT with noise.
     """
     def __init__(
         self, *,
@@ -716,6 +714,8 @@ class MultiBandCoaddsDM(object):
         Default info
     use_stack_interp: bool
         If True, use the stacks interpolation, default False
+    interp_bright: bool
+        If True, mark BRIGHT as SAT and do interpolation
     """
     def __init__(
         self, *,
@@ -726,11 +726,13 @@ class MultiBandCoaddsDM(object):
         byband=True,
         show=False,
         loglevel='info',
+        interp_bright=False,
         use_stack_interp=False,
     ):
 
         assert use_stack_interp is False
 
+        self.interp_bright = interp_bright
         self._show = show
         self.log = lsst.log.getLogger("MultiBandCoadds")
         self.log.setLevel(getattr(lsst.log, loglevel.upper()))
@@ -815,7 +817,8 @@ class MultiBandCoaddsDM(object):
                 if not self.use_stack_interp:
                     zero_bits(image=image, noise=noise, mask=bmask, flags=EDGE)
 
-                    flag_bright_as_interp(mask=bmask)
+                    if self.interp_bright:
+                        flag_bright_as_interp(mask=bmask)
 
                     iimage, inoise = interpolate_image_and_noise(
                         image=image,

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -192,7 +192,7 @@ class MultiBandCoadds(object):
                         flags=afw_image.Mask.getPlaneBitMask('EDGE'),
                     )
                     if self.interp_bright:
-                        flag_bright_as_interp(mask=bmask)
+                        flag_bright_as_sat(mask=bmask)
 
                     image, noise = interpolate_image_and_noise(
                         image=image,
@@ -834,7 +834,7 @@ class MultiBandCoaddsDM(object):
                     )
 
                     if self.interp_bright:
-                        flag_bright_as_interp(mask=bmask)
+                        flag_bright_as_sat(mask=bmask)
 
                     iimage, inoise = interpolate_image_and_noise(
                         image=image,
@@ -1486,7 +1486,7 @@ def zero_bits(*, image, noise, mask, flags):
         noise[w] = 0.0
 
 
-def flag_bright_as_interp(*, mask):
+def flag_bright_as_sat(*, mask):
     """
     flag BRIGHT also as SAT so no detections will occur there
 

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -27,6 +27,9 @@ from .interp import interpolate_image_and_noise, replace_flag_with_noise
 
 # only place to get this for now
 # from descwl_shear_sims.lsst_bits import BRIGHT
+# TODO figure out how to add this as a mask plane for the exposures
+# we generate in the sim, and add it to the calexp after we read them
+# and find bright stars etc.
 BRIGHT = np.int32(2**30)
 
 EDGE = afw_image.Mask.getPlaneBitMask('EDGE')

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -26,7 +26,8 @@ from . import vis
 from .interp import interpolate_image_and_noise, replace_flag_with_noise
 
 # only place to get this for now
-from descwl_shear_sims.lsst_bits import BRIGHT
+# from descwl_shear_sims.lsst_bits import BRIGHT
+BRIGHT = np.int32(2**30)
 
 EDGE = afw_image.Mask.getPlaneBitMask('EDGE')
 

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -858,10 +858,12 @@ class MultiBandCoaddsDM(object):
                 cx += psf_offset.x
                 psf_crpix = geom.Point2D(x=cx, y=cy)
 
+                cd_matrix = wcs.getCdMatrix(pos)
+
                 psf_stack_wcs = makeSkyWcs(
                     crpix=psf_crpix,
                     crval=coadd_sky_orig,
-                    cdMatrix=coadd_cd_matrix,
+                    cdMatrix=cd_matrix,
                 )
                 # TODO: deal with zeros
 

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -242,6 +242,11 @@ class MultiBandCoadds(object):
                 nexp = afw_image.ExposureF(nmasked_image)
                 psf_exp = afw_image.ExposureF(pmasked_image)
 
+                filter_label = afw_image.FilterLabel(band=band, physical=band)
+                exp.setFilterLabel(filter_label)
+                nexp.setFilterLabel(filter_label)
+                psf_exp.setFilterLabel(filter_label)
+
                 exp.setPsf(make_stack_psf(psf_image))
                 nexp.setPsf(make_stack_psf(psf_image))
 

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -686,7 +686,7 @@ class CoaddObs(ngmix.Observation):
         )
 
 
-class MultiBandCoaddsDMExps(object):
+class MultiBandCoaddsDM(object):
     """
     Coadd images within and across bands with input DM exposures
 
@@ -801,7 +801,7 @@ class MultiBandCoaddsDMExps(object):
 
                 image = exp.image.array
                 bmask = exp.mask.array
-                noise = noise_exp.noise.array
+                noise = noise_exp.image.array
 
                 var = exp.variance.array
 
@@ -869,6 +869,7 @@ class MultiBandCoaddsDMExps(object):
 
                 psf_exp = afw_image.ExposureF(pmasked_image)
 
+                psf_exp.setFilterLabel(exp.getFilterLabel())
                 psf_exp.setWcs(psf_stack_wcs)
                 detector = DetectorWrapper().detector
                 psf_exp.setDetector(detector)
@@ -1002,7 +1003,7 @@ class CoaddObsDM(ngmix.Observation):
         self.exps = exps
         self.psf_exps = psf_exps
         self.noise_exps = noise_exps
-        self.coadd_wcs = make_stack_wcs(coadd_wcs)
+        self.coadd_wcs = coadd_wcs
         self.coadd_dims = coadd_dims
         self.psf_dims = psf_dims
 

--- a/descwl_coadd/interp.py
+++ b/descwl_coadd/interp.py
@@ -9,6 +9,11 @@ from scipy.interpolate import CloughTocher2DInterpolator
 import numba
 from numba import njit
 
+# max allowed mask fraction for single epoch image going into coadd
+# TODO make this configurable
+# TODO do we even need this?  Should be checking at the warp level
+MAX_BADFRAC = 0.9
+
 
 @njit
 def _get_nearby_good_pixels(image, bad_msk, nbad, buff=4):
@@ -111,7 +116,7 @@ def _grid_interp(*, image, bad_msk):
     nbad = bad_msk.sum()
     bm_frac = nbad/npix
 
-    if bm_frac < 0.90:
+    if bm_frac < MAX_BADFRAC:
 
         bad_pix, good_pix, good_im, good_ind = \
             _get_nearby_good_pixels(image, bad_msk, nbad)

--- a/descwl_coadd/online_coadds.py
+++ b/descwl_coadd/online_coadds.py
@@ -7,7 +7,10 @@ TODO
 """
 import lsst.afw.math as afw_math
 import lsst.afw.image as afw_image
-from lsst.pipe.tasks.accumulatorMeanStack import AccumulatorMeanStack
+from lsst.pipe.tasks.accumulatorMeanStack import (
+    AccumulatorMeanStack,
+    stats_ctrl_to_threshold_dict,
+)
 from lsst.pipe.tasks.assembleCoadd import AssembleCoaddTask
 from lsst.daf.butler import DeferredDatasetHandle
 

--- a/descwl_coadd/online_coadds.py
+++ b/descwl_coadd/online_coadds.py
@@ -4,6 +4,21 @@ TODO
     - psf coadds
     - noise coadds; may want to generate the noise images on the fly
       within this code
+
+So I'll just set andMask for EDGE and all other bits get passed on, and I can
+check on the fly if there are any EDGE in the coadd region
+
+Reject warps with NO_DATA set; for HSC this can be set for chips near the edge
+of the focal plane
+
+check EDGE and NO_DATA are not set in warp mask, eli expects NO_DATA should not be set
+
+Note, warps are the exact size of the coadd, which for standard patches is
+bigger than an image so we can't do any of this yet!
+
+Then check bits for masked fraction
+    bad = np.where(mask & BADSTUFF != 0)
+    maskfrac = bad[0].size / mask.size
 """
 import lsst.afw.math as afw_math
 import lsst.afw.image as afw_image

--- a/descwl_coadd/online_coadds.py
+++ b/descwl_coadd/online_coadds.py
@@ -13,13 +13,16 @@ of the focal plane
 
 check EDGE and NO_DATA are not set in warp mask, eli expects NO_DATA should not be set
 
-Note, warps are the exact size of the coadd, which for standard patches is
+BUT, warps are the exact size of the coadd, which for standard patches is
 bigger than an image so we can't do any of this yet!
 
 Then check bits for masked fraction
     bad = np.where(mask & BADSTUFF != 0)
     maskfrac = bad[0].size / mask.size
 """
+import numpy as np
+import ngmix
+from lsst.afw.geom import makeSkyWcs
 import lsst.afw.math as afw_math
 import lsst.afw.image as afw_image
 from lsst.pipe.tasks.accumulatorMeanStack import (
@@ -28,11 +31,68 @@ from lsst.pipe.tasks.accumulatorMeanStack import (
 )
 from lsst.pipe.tasks.assembleCoadd import AssembleCoaddTask
 from lsst.daf.butler import DeferredDatasetHandle
+import lsst.log
+import lsst.geom as geom
+from lsst.afw.cameraGeom.testUtils import DetectorWrapper
+from lsst.meas.algorithms import KernelPsf
+from lsst.afw.math import FixedKernel
 
-INTERP = 'lanczos3'
+from . import vis
+
+DEFAULT_INTERP = 'lanczos3'
+DEFAULT_LOGLEVEL = 'info'
 
 
-def make_online_coadd(exps, coadd_wcs, coadd_bbox):
+def make_online_coadd_obs(
+    exps, coadd_wcs, coadd_bbox, psf_dims, rng, remove_poisson,
+    loglevel=DEFAULT_LOGLEVEL,
+):
+    """
+    Make a coadd from the input exposures and store in a CoaddObs, which
+    inherits from ngmix.Observation. See make_online_coadd for docs on online
+    coadding.
+
+    Parameters
+    ----------
+    exps: list
+        Either a list of exposures or a list of DeferredDatasetHandle
+    coadd_wcs: DM wcs object
+        The target wcs
+    coadd_bbox: geom.Box2I
+        The bounding fox for the coadd
+    psf_dims: tuple
+        The dimensions of the psf
+    rng: np.random.RandomState
+        The random number generator for making noise images
+    remove_poisson: bool
+        If True, remove the poisson noise from the variance
+        estimate.
+    loglevel : str, optional
+        The logging level. Default is 'info'.
+
+    Returns
+    -------
+    CoaddObs (inherits from ngmix.Observation)
+    """
+
+    coadd_exp, coadd_noise_exp, coadd_psf_exp = make_online_coadd(
+        exps=exps, coadd_wcs=coadd_wcs, coadd_bbox=coadd_bbox,
+        psf_dims=psf_dims,
+        rng=rng, remove_poisson=remove_poisson,
+        loglevel=loglevel,
+    )
+    return CoaddObs(
+        coadd_exp=coadd_exp,
+        coadd_noise_exp=coadd_noise_exp,
+        coadd_psf_exp=coadd_psf_exp,
+        loglevel=loglevel,
+    )
+
+
+def make_online_coadd(
+    exps, coadd_wcs, coadd_bbox, psf_dims, rng, remove_poisson,
+    loglevel=DEFAULT_LOGLEVEL,
+):
     """
     make a coadd from the input exposures, working in "online mode",
     adding each exposure separately.  This saves memory when
@@ -46,58 +106,179 @@ def make_online_coadd(exps, coadd_wcs, coadd_bbox):
         The target wcs
     coadd_bbox: geom.Box2I
         The bounding fox for the coadd
+    psf_dims: tuple
+        The dimensions of the psf
+    rng: np.random.RandomState
+        The random number generator for making noise images
+    remove_poisson: bool
+        If True, remove the poisson noise from the variance
+        estimate.
+    loglevel : str, optional
+        The logging level. Default is 'info'.
 
     Returns
     -------
     ExposureF for coadd
     """
+
+    logger = make_logger('online_coadds', loglevel)
+
+    coadd_psf_bbox = geom.Box2I(
+        geom.Point2I(0, 0),
+        geom.Point2I(psf_dims[0]-1, psf_dims[1]-1),
+    )
+    coadd_psf_wcs = get_coadd_psf_wcs(coadd_wcs, psf_dims)
+
+    # separately stack data, noise, and psf
     coadd_exp = afw_image.ExposureF(coadd_bbox, coadd_wcs)
+    coadd_noise_exp = afw_image.ExposureF(coadd_bbox, coadd_wcs)
+    coadd_psf_exp = afw_image.ExposureF(coadd_psf_bbox, coadd_psf_wcs)
 
-    coadd_stats_ctrl = get_coadd_stats_control(
-        afw_image.Mask.getPlaneBitMask('EDGE')
-    )
+    mask = afw_image.Mask.getPlaneBitMask('EDGE')
+    coadd_dims = coadd_exp.image.array.shape,
 
-    stacker = make_online_stacker(
-        coadd_stats_ctrl, coadd_exp.image.array.shape,
-    )
+    stacker = make_online_stacker(mask=mask, coadd_dims=coadd_dims)
+    noise_stacker = make_online_stacker(mask=mask, coadd_dims=coadd_dims)
+    psf_stacker = make_online_stacker(mask=mask, coadd_dims=psf_dims)
 
+    # can re-use the warper for each coadd type
     warp_config = afw_math.Warper.ConfigClass()
-    warp_config.warpingKernelName = INTERP
+    warp_config.warpingKernelName = DEFAULT_INTERP
     warper = afw_math.Warper.fromConfig(warp_config)
 
-    for texp in exps:
-        if isinstance(texp, DeferredDatasetHandle):
-            exp = texp.get()
-        else:
-            exp = texp
+    # will zip these with the exposures to warp and add
+    stackers = [stacker, noise_stacker, psf_stacker]
+    wcss = [coadd_wcs, coadd_wcs, coadd_psf_wcs]
+    bboxes = [coadd_bbox, coadd_bbox, coadd_psf_bbox]
+
+    for exp_or_ref in exps:
+        exp, noise_exp = get_exp_and_noise(
+            exp_or_ref=exp_or_ref, rng=rng, remove_poisson=remove_poisson,
+        )
+        psf_exp = get_psf_exp(exp, coadd_wcs)
 
         weight = get_exp_weight(exp)
 
-        wexp = warper.warpExposure(
-            coadd_wcs,
-            exp,
-            maxBBox=exp.getBBox(),
-            destBBox=coadd_bbox,
-        )
+        # order must match stackers, wcss, bboxes
+        exps2add = [exp, noise_exp, psf_exp]
 
-        stacker.add_masked_image(wexp.image, weight=weight)
+        for _stacker, _exp, _wcs, _bbox in zip(stackers, exps2add, wcss, bboxes):
+            warp_and_add(
+                _stacker, warper, _exp, _wcs, _bbox, weight,
+            )
 
     stacker.fill_stacked_masked_image(coadd_exp.image)
+    noise_stacker.fill_stacked_masked_image(coadd_noise_exp.image)
+    psf_stacker.fill_stacked_masked_image(coadd_psf_exp.image)
 
-    return coadd_exp
+    psf = extract_coadd_psf(coadd_psf_exp, logger)
+    coadd_exp.setPsf(psf)
+    coadd_noise_exp.setPsf(psf)
+
+    return coadd_exp, coadd_noise_exp
 
 
-def make_online_stacker(stats_ctrl, coadd_dims):
+def extract_coadd_psf(coadd_psf_exp, logger):
+    """
+    extract the PSF image, zeroing the image where
+    there are "bad" pixels, associated with areas not
+    covered by the input psfs
+
+    Parameters
+    ----------
+    coadd_psf_exp: afw_image.ExposureF
+        The psf exposure
+
+    Returns
+    -------
+    KernelPsf
+    """
+    psf_image = coadd_psf_exp.image.array
+
+    wbad = np.where(~np.isfinite(psf_image))
+    if wbad[0].size == psf_image.size:
+        raise ValueError('no good pixels in the psf')
+
+    if wbad[0].size > 0:
+        logger.info('zeroing %d bad psf pixels' % wbad[0].size)
+        psf_image[wbad] = 0.0
+
+    return KernelPsf(
+        FixedKernel(
+            afw_image.ImageD(psf_image.astype(np.float))
+        )
+    )
+
+
+def get_exp_and_noise(exp_or_ref, rng, remove_poisson):
+    """
+    get the exposure (possibly from a deferred handle) and create
+    a corresponding noise exposure
+
+    Parameters
+    ----------
+    exp_or_ref: afw_image.ExposureF or DeferredDatasetHandle
+        The input exposure, possible deferred
+
+    Returns
+    -------
+    exp, noise_exp
+    """
+    if isinstance(exp_or_ref, DeferredDatasetHandle):
+        exp = exp_or_ref.get()
+    else:
+        exp = exp
+
+    noise_exp = get_noise_exp(
+        exp=exp, rng=rng, remove_poisson=remove_poisson,
+    )
+    return exp, noise_exp
+
+
+def warp_and_add(stacker, warper, exp, coadd_wcs, coadd_bbox, weight):
+    """
+    warp the exposure and add it
+
+    Parameters
+    ----------
+    stacker: AccumulatorMeanStack
+        A stacker, type
+        lsst.pipe.tasks.accumulatorMeanStack.AccumulatorMeanStack
+    warper: afw_math.Warper
+        The warper
+    exp: afw_image.ExposureF
+        The exposure to warp and add
+    coadd_wcs: DM wcs object
+        The target wcs
+    coadd_bbox: geom.Box2I
+        The bounding fox for the coadd
+    weight: float
+        Weight for this image in the stack
+    """
+    wexp = warper.warpExposure(
+        coadd_wcs,
+        exp,
+        maxBBox=exp.getBBox(),
+        destBBox=coadd_bbox,
+    )
+    stacker.add_masked_image(wexp.image, weight=weight)
+
+
+def make_online_stacker(mask, coadd_dims):
     """
     make an AccumulatorMeanStack to online coadding
 
     Parameters
     ----------
-    stats_ctrl: afw_math.StatisticsControl
-        The stats control
+    mask: int
+        The mask bits for andMask
     coadd_bbox: geom.Box2I
         The coadd bbox
     """
+
+    stats_ctrl = get_coadd_stats_control(
+        mask=afw_image.Mask.getPlaneBitMask('EDGE')
+    )
 
     mask_map = AssembleCoaddTask.setRejectedMaskMapping(stats_ctrl)
 
@@ -185,3 +366,326 @@ def get_dims_from_bbox(bbox):
 
     # dims is C/numpy ordering
     return nrows, ncols
+
+
+def get_noise_exp(exp, rng, remove_poisson):
+    """
+    get a noise image based on the input exposure
+
+    TODO gain correct separately in each amplifier, currently
+    averaged
+
+    Parameters
+    ----------
+    exp: afw.image.ExposureF
+        The exposure upon which to base the noise
+    rng: np.random.RandomState
+        The random number generator for making the noise image
+    remove_poisson: bool
+        If True, remove the poisson noise from the variance
+        estimate.
+
+    Returns
+    -------
+    noise exposure
+    """
+    signal = exp.image.array
+    variance = exp.variance.array.copy()
+
+    use = np.where(np.isfinite(variance) & np.isfinite(signal))
+
+    if remove_poisson:
+        gains = [
+            amp.getGain() for amp in exp.getDetector().getAmplifiers()
+        ]
+        mean_gain = np.mean(gains)
+
+        corrected_var = variance[use] - signal[use] / mean_gain
+
+        medvar = np.median(corrected_var)
+    else:
+        medvar = np.median(variance[use])
+
+    noise_image = rng.normal(scale=np.sqrt(medvar), size=signal.shape)
+
+    ny, nx = signal.shape
+    nmimage = afw_image.MaskedImageF(width=nx, height=ny)
+    assert nmimage.image.array.shape == (ny, nx)
+
+    nmimage.image.array[:, :] = noise_image
+    nmimage.variance.array[:, :] = medvar
+    nmimage.mask.array[:, :] = exp.mask.array[:, :]
+
+    noise_exp = afw_image.ExposureF(nmimage)
+    noise_exp.setPsf(exp.getPsf())
+    noise_exp.setWcs(exp.getWcs())
+    noise_exp.setFilterLabel(exp.getFilterLabel())
+    noise_exp.setDetector(exp.getDetector())
+
+    return noise_exp
+
+
+def get_psf_exp(exp, coadd_wcs):
+    """
+    create a psf exposure to be coadded, rendered at the
+    position in the exposure corresponding to the center of the
+    coadd
+
+    Parameters
+    ----------
+    exp: afw_image.ExposureF
+        The exposure
+    coadd_wcs: DM wcs
+        The wcs for the coadd
+
+    Returns
+    -------
+    psf ExposureF
+    """
+    coadd_sky_orig = coadd_wcs.getSkyOrigin()
+    wcs = exp.getWcs()
+    pos = wcs.skyToPixel(coadd_sky_orig)
+
+    psf_obj = exp.getPsf()
+    psf_image = psf_obj.computeImage(pos).array
+    psf_offset = get_psf_offset(pos)
+
+    cy, cx = (np.array(psf_image.shape)-1)/2
+    cy += psf_offset.y
+    cx += psf_offset.x
+    psf_crpix = geom.Point2D(x=cx, y=cy)
+
+    cd_matrix = wcs.getCdMatrix(pos)
+
+    psf_stack_wcs = makeSkyWcs(
+        crpix=psf_crpix,
+        crval=coadd_sky_orig,
+        cdMatrix=cd_matrix,
+    )
+    # TODO: deal with zeros
+
+    # an exp for the PSF
+    # we need to put a var here that is consistent with the
+    # main image to get a consistent coadd.  I'm not sure
+    # what the best choice is, using median for now TODO
+
+    var = exp.variance.array
+
+    pny, pnx = psf_image.shape
+    pmasked_image = afw_image.MaskedImageF(pny, pnx)
+    pmasked_image.image.array[:, :] = psf_image
+    pmasked_image.variance.array[:, :] = np.median(var)
+    pmasked_image.mask.array[:, :] = 0
+
+    psf_exp = afw_image.ExposureF(pmasked_image)
+
+    psf_exp.setFilterLabel(exp.getFilterLabel())
+    psf_exp.setWcs(psf_stack_wcs)
+    detector = DetectorWrapper().detector
+    psf_exp.setDetector(detector)
+    return psf_exp
+
+
+class CoaddObs(ngmix.Observation):
+    """
+    Class representing a coadd observation
+
+    Note that this class is a subclass of an `ngmix.Observation` and so it has
+    all of the usual methods and attributes.
+
+    Parameters
+    ----------
+    coadd_exp : afw_image.ExposureF
+        The coadd exposure
+    noise_exp : afw_image.ExposureF
+        The coadded noise exposure
+    coadd_psf_exp : afw_image.ExposureF
+        The psf coadd
+    loglevel : str, optional
+        The logging level. Default is 'info'.
+    """
+    def __init__(
+        self, *,
+        coadd_exp,
+        coadd_noise_exp,
+        coadd_psf_exp,
+        loglevel='info',
+    ):
+
+        self.log = make_logger('CoaddObs', loglevel)
+
+        self.coadd_exp = coadd_exp
+        self.coadd_psf_exp = coadd_psf_exp
+        self.coadd_noise_exp = coadd_noise_exp
+
+        self._finish_init()
+
+    def show(self):
+        """
+        show the output coadd in DS9
+        """
+        self.log.info('showing coadd in ds9')
+        vis.show_image_and_mask(self.coadd_exp)
+        # this will block
+        vis.show_images(
+            [
+                self.image,
+                self.coadd_exp.mask.array,
+                self.noise,
+                self.coadd_noise_exp.mask.array,
+                self.coadd_psf_exp.image.array,
+                # self.weight,
+            ],
+        )
+
+    def _get_jac(self, *, cenx, ceny):
+        """
+        get jacobian at the coadd image center
+
+        make an ngmix jacobian with specified center specified (this is not the
+        position used to evaluate the jacobian)
+
+        Parameters
+        ----------
+        cenx: float
+            Center for the output ngmix jacobian (not place of evaluation)
+        ceny: float
+            Center for the output ngmix jacobian (not place of evaluation)
+        """
+
+        coadd_wcs = self.coadd_exp.getWcs()
+        coadd_cen = coadd_wcs.getPixelOrigin()
+        dm_jac = coadd_wcs.linearizePixelToSky(coadd_cen, geom.arcseconds)
+        matrix = dm_jac.getLinear().getMatrix()
+
+        # note convention differences
+        return ngmix.Jacobian(
+            x=cenx,
+            y=ceny,
+            dudx=matrix[1, 1],
+            dudy=-matrix[1, 0],
+            dvdx=matrix[0, 1],
+            dvdy=-matrix[0, 0],
+        )
+
+    def _get_coadd_psf_obs(self):
+        """
+        get the psf observation
+        """
+
+        coadd_wcs = self.coadd_exp.getWcs()
+        coadd_cen = coadd_wcs.getPixelOrigin()
+
+        psf_obj = self.coadd_exp.getPsf()
+        psf_image = psf_obj.computeKernelImage(coadd_cen).array
+
+        psf_cen = (np.array(psf_image.shape)-1.0)/2.0
+
+        psf_jac = self._get_jac(cenx=psf_cen[1], ceny=psf_cen[0])
+
+        psf_err = psf_image.max()*0.0001
+        psf_weight = psf_image*0 + 1.0/psf_err**2
+
+        return ngmix.Observation(
+            image=psf_image,
+            weight=psf_weight,
+            jacobian=psf_jac,
+        )
+
+    def _finish_init(self):
+        """
+        finish the init by sending the image etc. to the
+        Observation init
+        """
+        psf_obs = self._get_coadd_psf_obs()  # noqa
+
+        image = self.coadd_exp.image.array
+        noise = self.coadd_noise_exp.image.array
+
+        var = self.coadd_exp.variance.array.copy()
+        wnf = np.where(~np.isfinite(var))
+
+        if wnf[0].size == image.size:
+            raise ValueError('no good variance values')
+
+        if wnf[0].size > 0:
+            var[wnf] = -1
+
+        weight = var.copy()
+        weight[:, :] = 0.0
+
+        w = np.where(var > 0)
+        weight[w] = 1.0/var[w]
+
+        if wnf[0].size > 0:
+            # medval = np.sqrt(np.median(var[w]))
+            # weight[wbad] = medval
+            # TODO: add noise instead based on medval, need to send in rng
+            image[wnf] = 0.0
+            noise[wnf] = 0.0
+
+        cen = (np.array(image.shape)-1)/2
+        jac = self._get_jac(cenx=cen[1], ceny=cen[0])
+
+        super().__init__(
+            image=image,
+            noise=noise,
+            weight=weight,
+            bmask=np.zeros(image.shape, dtype='i4'),
+            ormask=self.coadd_exp.mask.array,
+            jacobian=jac,
+            psf=psf_obs,
+            store_pixels=False,
+        )
+
+
+def get_psf_offset(pos):
+    """
+    the offset where the psf ends up landing with computeImage
+    I don't know if this actually works or not for real psfs
+
+    Parameters
+    ----------
+    pos: geom.Point2D
+        The position requested for the reconstruction
+    """
+    return geom.Point2D(
+        x=pos.x - int(pos.x + 0.5),
+        y=pos.y - int(pos.y + 0.5),
+    )
+
+
+def get_coadd_psf_wcs(coadd_wcs, psf_dims):
+    """
+    create the coadd psf wcs
+
+    Parameters
+    ----------
+    coadd_wcs: DM wcs
+        The coadd wcs
+    psf_dims: tuple
+        The dimensions of the psf
+
+    Returns
+    -------
+    A DM SkyWcs
+    """
+    cy, cx = (np.array(psf_dims)-1)/2
+    psf_crpix = geom.Point2D(x=cx, y=cy)
+
+    coadd_sky_orig = coadd_wcs.getSkyOrigin()
+    coadd_cd_matrix = coadd_wcs.getCdMatrix(coadd_wcs.getPixelOrigin())
+
+    return makeSkyWcs(
+        crpix=psf_crpix,
+        crval=coadd_sky_orig,
+        cdMatrix=coadd_cd_matrix,
+    )
+
+
+def make_logger(name, loglevel):
+    """
+    make a logger with the specified loglevel
+    """
+    logger = lsst.log.getLogger(name)
+    logger.setLevel(getattr(lsst.log, loglevel.upper()))

--- a/descwl_coadd/online_coadds.py
+++ b/descwl_coadd/online_coadds.py
@@ -1,0 +1,173 @@
+"""
+TODO
+    - actually try to run it
+    - psf coadds
+    - noise coadds; may want to generate the noise images on the fly
+      within this code
+"""
+import lsst.afw.math as afw_math
+import lsst.afw.image as afw_image
+from lsst.pipe.tasks.accumulatorMeanStack import AccumulatorMeanStack
+from lsst.pipe.tasks.assembleCoadd import AssembleCoaddTask
+from lsst.daf.butler import DeferredDatasetHandle
+
+INTERP = 'lanczos3'
+
+
+def make_online_coadd(exps, coadd_wcs, coadd_bbox):
+    """
+    make a coadd from the input exposures, working in "online mode",
+    adding each exposure separately.  This saves memory when
+    the exposures are being read from disk
+
+    Parameters
+    ----------
+    exps: list
+        Either a list of exposures or a list of DeferredDatasetHandle
+    coadd_wcs: DM wcs object
+        The target wcs
+    coadd_bbox: geom.Box2I
+        The bounding fox for the coadd
+
+    Returns
+    -------
+    ExposureF for coadd
+    """
+    coadd_exp = afw_image.ExposureF(coadd_bbox, coadd_wcs)
+
+    coadd_stats_ctrl = get_coadd_stats_control(
+        afw_image.Mask.getPlaneBitMask('EDGE')
+    )
+
+    stacker = make_online_stacker(coadd_stats_ctrl, coadd_bbox)
+
+    warp_config = afw_math.Warper.ConfigClass()
+    warp_config.warpingKernelName = INTERP
+    warper = afw_math.Warper.fromConfig(warp_config)
+
+    for texp in exps:
+        if isinstance(texp, DeferredDatasetHandle):
+            exp = texp.get()
+        else:
+            exp = texp
+
+        weight = get_exp_weight(exp)
+
+        wexp = warper.warpExposure(
+            coadd_wcs,
+            exp,
+            maxBBox=exp.getBBox(),
+            destBBox=coadd_bbox,
+        )
+
+        stacker.add_masked_image(wexp.image, weight=weight)
+
+        # if isinstance(texp, DeferredDatasetHandle):
+        #     # is this needed?
+        #     del exp
+
+    stacker.fill_stacked_masked_image(coadd_exp.image)
+
+    return coadd_exp
+
+
+def make_online_stacker(stats_ctrl, coadd_bbox):
+    """
+    make an AccumulatorMeanStack to online coadding
+
+    Parameters
+    ----------
+    stats_ctrl: afw_math.StatisticsControl
+        The stats control
+    coadd_bbox: geom.Box2I
+        The coadd bbox
+    """
+
+    # dims is C/numpy ordering
+    dims = get_dims_from_bbox(coadd_bbox)
+
+    mask_map = AssembleCoaddTask.setRejectedMaskMapping(stats_ctrl)
+
+    return AccumulatorMeanStack(
+        shape=dims,
+        bit_mask_value=stats_ctrl.getAndMask(),
+        mask_threshold_dict={},
+        mask_map=mask_map,
+        no_good_pixels_mask=stats_ctrl.getNoGoodPixelsMask(),
+        calc_error_from_input_variance=True,
+        compute_n_image=False,
+    )
+
+
+def get_coadd_stats_control(mask):
+    """
+    get a afw_math.StatisticsControl with "and mask" set
+
+    Parameters
+    ----------
+    mask: mask for setAndMask
+        Bits for which the pixels will not be added to the coadd.
+        e.g. we would not let EDGE pixels get coadded
+
+    Returns
+    -------
+    afw_math.StatisticsControl
+    """
+    stats_ctrl = afw_math.StatisticsControl()
+    stats_ctrl.setAndMask(mask)
+    stats_ctrl.setWeighted(True)
+    stats_ctrl.setCalcErrorFromInputVariance(True)
+
+    # statsFlags = afw_math.stringToStatisticsProperty(self.config.statistic)
+    # return pipeBase.Struct(ctrl=statsCtrl, flags=statsFlags)
+
+    return stats_ctrl
+
+
+def get_exp_weight(exp):
+    """
+    get a afw_math.StatisticsControl with "and mask" set
+
+    Parameters
+    ----------
+    mask: mask for setAndMask
+        Bits for which the pixels will not be added to the coadd.
+        e.g. we would not let EDGE pixels get coadded
+
+    Returns
+    -------
+    afw_math.StatisticsControl
+    """
+    # Compute variance weight
+    stats_ctrl = afw_math.StatisticsControl()
+    stats_ctrl.setCalcErrorFromInputVariance(True)
+    stat_obj = afw_math.makeStatistics(
+        exp.variance,
+        exp.mask,
+        afw_math.MEANCLIP,
+        stats_ctrl,
+    )
+
+    mean_var, mean_var_err = stat_obj.getResult(afw_math.MEANCLIP)
+    weight = 1.0 / float(mean_var)
+    return weight
+
+
+def get_dims_from_bbox(bbox):
+    """
+    get (nrows, ncols) numpy style from bbox
+
+    Parameters
+    ----------
+    bbox: geom.Box2I
+        The bbox
+
+    Returns
+    -------
+    (nrows, ncols)
+    """
+    ncols = bbox.getEndX() - bbox.getBeginX()
+    nrows = bbox.getEndY() - bbox.getBeginY()
+
+    # dims is C/numpy ordering
+    return nrows, ncols

--- a/descwl_coadd/tests/test_coadd_sim.py
+++ b/descwl_coadd/tests/test_coadd_sim.py
@@ -1,0 +1,136 @@
+import pytest
+import numpy as np
+
+from descwl_shear_sims.sim import (
+    make_dmsim,
+    make_galaxy_catalog,
+    StarCatalog,
+    make_psf,
+    make_ps_psf,
+    get_se_dim,
+)
+
+from ..coadd import MultiBandCoaddsDM
+
+
+def _make_sim(rng, psf_type):
+    seed = 431
+    rng = np.random.RandomState(seed)
+    buff = 5
+
+    coadd_dim = 101
+    galaxy_catalog = make_galaxy_catalog(
+        rng=rng,
+        gal_type="exp",
+        coadd_dim=coadd_dim,
+        buff=buff,
+        layout="grid",
+    )
+
+    if psf_type == "ps":
+        se_dim = get_se_dim(coadd_dim=coadd_dim)
+        psf = make_ps_psf(rng=rng, dim=se_dim)
+    else:
+        psf = make_psf(psf_type=psf_type)
+
+    star_catalog = StarCatalog(
+        rng=rng,
+        coadd_dim=coadd_dim,
+        buff=buff,
+        density=100,
+    )
+
+    return make_dmsim(
+        rng=rng,
+        galaxy_catalog=galaxy_catalog,
+        star_catalog=star_catalog,
+        coadd_dim=coadd_dim,
+        g1=0.02,
+        g2=0.00,
+        psf=psf,
+        dither=True,
+        rotate=True,
+    )
+
+
+# @pytest.mark.parametrize('psf_type', ['gauss', 'ps'])
+@pytest.mark.parametrize('psf_type', ['gauss'])
+def test_coadd_obs_smoke(psf_type):
+    rng = np.random.RandomState(8312)
+    data = _make_sim(rng, psf_type)
+
+    coadd_dims = data['coadd_dims']
+    psf_dims = data['psf_dims']
+
+    # coadding individual bands as well as over bands
+
+    coadds = MultiBandCoaddsDM(
+        data=data['band_data'],
+        coadd_wcs=data['coadd_wcs'],
+        coadd_dims=coadd_dims,
+        psf_dims=psf_dims,
+    )
+
+    coadd = coadds.get_coadd()
+    assert coadd.coadd_exp.image.array.shape == coadd_dims
+    assert coadd.image.shape == coadd_dims
+    assert coadd.noise.shape == coadd_dims
+    assert coadd.psf.image.shape == psf_dims
+
+    for band in coadds.bands:
+        bcoadd = coadds.get_coadd(band=band)
+        assert bcoadd.coadd_exp.image.array.shape == coadd_dims
+        assert bcoadd.image.shape == coadd_dims
+        assert bcoadd.noise.shape == coadd_dims
+        assert bcoadd.psf.image.shape == psf_dims
+
+    # not coadding individual bands
+    coadds = MultiBandCoaddsDM(
+        data=data['band_data'],
+        coadd_wcs=data['coadd_wcs'],
+        coadd_dims=coadd_dims,
+        psf_dims=psf_dims,
+        byband=False,
+    )
+
+    for band in coadds.bands:
+        assert band not in coadds.coadds
+
+
+'''
+def test_coadd_obs_weights():
+    """
+    ensure the psf and noise var are set close, so
+    that the relative weight is right
+    """
+    rng = np.random.RandomState(8312)
+    sim = SimpleSim(
+        rng=rng,
+        epochs_per_band=2,
+    )
+    data = sim.gen_sim()
+
+    coadd_dims = (sim.coadd_dim,)*2
+
+    # coadding individual bands as well as over bands
+    psf_dim = sim.psf_dim
+    psf_dims = (psf_dim,)*2
+
+    coadds = MultiBandCoaddsDM(
+        data=data,
+        coadd_wcs=sim.coadd_wcs,
+        coadd_dims=coadd_dims,
+        psf_dims=psf_dims,
+    )
+
+    for exp, pexp, nexp in zip(coadds.exps,
+                               coadds.psf_exps,
+                               coadds.noise_exps):
+
+        emed = np.median(exp.variance.array)
+        pmed = np.median(pexp.variance.array)
+        nmed = np.median(nexp.variance.array)
+
+        assert abs(pmed/emed-1) < 1.0e-3
+        assert abs(nmed/emed-1) < 1.0e-3
+'''

--- a/descwl_coadd/tests/test_coadd_sim.py
+++ b/descwl_coadd/tests/test_coadd_sim.py
@@ -60,14 +60,17 @@ def test_coadd_sim_smoke(psf_type):
     rng = np.random.RandomState(8312)
     data = _make_sim(rng, psf_type)
 
-    coadd_dims = data['coadd_dims']
+    extent = data['coadd_bbox'].getDimensions()
+    coadd_dims = (extent.getX(), extent.getY())
+    assert data['coadd_dims'] == coadd_dims
+
     psf_dims = data['psf_dims']
 
     # coadding individual bands as well as over bands
     coadds = MultiBandCoaddsDM(
         data=data['band_data'],
         coadd_wcs=data['coadd_wcs'],
-        coadd_dims=coadd_dims,
+        coadd_bbox=data['coadd_bbox'],
         psf_dims=psf_dims,
     )
 
@@ -88,7 +91,7 @@ def test_coadd_sim_smoke(psf_type):
     coadds = MultiBandCoaddsDM(
         data=data['band_data'],
         coadd_wcs=data['coadd_wcs'],
-        coadd_dims=coadd_dims,
+        coadd_bbox=data['coadd_bbox'],
         psf_dims=psf_dims,
         byband=False,
     )
@@ -105,14 +108,13 @@ def test_coadd_sim_noise():
     rng = np.random.RandomState(32)
     data = _make_sim(rng=rng, psf_type='gauss')
 
-    coadd_dims = data['coadd_dims']
     psf_dims = data['psf_dims']
 
     # coadding individual bands as well as over bands
     coadds = MultiBandCoaddsDM(
         data=data['band_data'],
         coadd_wcs=data['coadd_wcs'],
-        coadd_dims=coadd_dims,
+        coadd_bbox=data['coadd_bbox'],
         psf_dims=psf_dims,
     )
 

--- a/descwl_coadd/vis.py
+++ b/descwl_coadd/vis.py
@@ -13,6 +13,9 @@ def show_image_and_mask(exp):
     display.mtv(exp)
     display.scale('log', 'minmax')
 
+    input('hit a key to show mask')
+    display.mtv(exp.mask)
+
 
 def show_image(image):
     """

--- a/descwl_coadd/vis.py
+++ b/descwl_coadd/vis.py
@@ -16,18 +16,26 @@ def show_image_and_mask(exp):
     input('hit a key to show mask')
     display.mtv(exp.mask)
 
+    input('hit a key to see psf')
 
-def show_image(image):
+
+def show_image(image, title=None):
     """
     show an image
     """
-    import matplotlib.pyplot as plt
-    plt.imshow(
+    import matplotlib.pyplot as mplt
+    fig, ax = mplt.subplots()
+
+    ax.imshow(
         image,
         interpolation='nearest',
         cmap='gray',
     )
-    plt.show()
+    if title is not None:
+        ax.set_title(title)
+
+    fig.show()
+    input('hit a key')
 
 
 def show_2images(im1, im2, title=None):


### PR DESCRIPTION
These are parallel versions with DM appended to the names.

They will replace the old ones once a full shear recover test has been passed