### PR TITLE
Write warps

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
             # specific version 3.8.8 is here to fix solver error w/ sqlite 
             # see https://lsstc.slack.com/archives/C2K9RHYTV/p1628567486002200
             # when python 3.9 is in use, set this to 3.9
-            pyver: [3.8.8, "3.10"]
+            pyver: ["3.10"]
 
       runs-on: "ubuntu-latest"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,10 +11,7 @@ jobs:
       name: tests
       strategy:
           matrix:
-            # specific version 3.8.8 is here to fix solver error w/ sqlite 
-            # see https://lsstc.slack.com/archives/C2K9RHYTV/p1628567486002200
-            # when python 3.9 is in use, set this to 3.9
-            pyver: ["3.10"]
+            pyver: ["3.10", "3.11"]
 
       runs-on: "ubuntu-latest"
 

--- a/descwl_coadd/__init__.py
+++ b/descwl_coadd/__init__.py
@@ -4,6 +4,7 @@ from .version import __version__
 
 from . import coadd
 from .coadd import make_coadd_obs, make_coadd, make_warps
+from .coadd import DEFAULT_INTERP, MAX_MASKFRAC
 from . import coadd_nowarp
 from .coadd_nowarp import make_coadd_obs_nowarp, make_coadd_nowarp
 from . import coadd_obs

--- a/descwl_coadd/__init__.py
+++ b/descwl_coadd/__init__.py
@@ -3,7 +3,7 @@
 from .version import __version__
 
 from . import coadd
-from .coadd import make_coadd_obs, make_coadd
+from .coadd import make_coadd_obs, make_coadd, make_warps
 from . import coadd_nowarp
 from .coadd_nowarp import make_coadd_obs_nowarp, make_coadd_nowarp
 from . import coadd_obs

--- a/descwl_coadd/__init__.py
+++ b/descwl_coadd/__init__.py
@@ -3,7 +3,7 @@
 from .version import __version__
 
 from . import coadd
-from .coadd import make_coadd_obs, make_coadd, make_warps
+from .coadd import make_coadd_obs, make_coadd, warp_exposures
 from .coadd import DEFAULT_INTERP, MAX_MASKFRAC
 from . import coadd_nowarp
 from .coadd_nowarp import make_coadd_obs_nowarp, make_coadd_nowarp

--- a/descwl_coadd/__init__.py
+++ b/descwl_coadd/__init__.py
@@ -3,7 +3,7 @@
 from .version import __version__
 
 from . import coadd
-from .coadd import make_coadd_obs, make_coadd, warp_exposures
+from .coadd import make_coadd_obs, make_coadd, warp_exposures, warp_psf
 from .coadd import DEFAULT_INTERP, MAX_MASKFRAC
 from . import coadd_nowarp
 from .coadd_nowarp import make_coadd_obs_nowarp, make_coadd_nowarp

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -519,7 +519,7 @@ def make_warps(
     try:
         mfrac_exp = make_mfrac_exp(mfrac_msk=bad_msk, exp=expobj)
 
-        if maskfrac > 0:
+        if 0 < maskfrac < 1:
             # images modified internally
             interp_nocheck(exp=expobj, noise_exp=noise_exp, bad_msk=bad_msk)
 

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -1,3 +1,7 @@
+"""
+TODO:
+    fill in stubbs for write_warps and load_warps
+"""
 import numpy as np
 import esutil as eu
 
@@ -90,6 +94,7 @@ def make_coadd_obs(
 def make_coadd(
     exps, coadd_wcs, coadd_bbox, psf_dims, rng, remove_poisson,
     max_maskfrac=MAX_MASKFRAC,
+    is_warps=False,
 ):
     """
     make a coadd from the input exposures, working in "online mode",
@@ -115,7 +120,9 @@ def make_coadd(
         Maximum allowed masked fraction.  Images masked more than
         this will not be included in the coadd.  Must be in range
         [0, 1]
-
+    is_warps: bool
+        If set to True the input exps are actually handles for a data set, from
+        which the warps and info can be loaded
     Returns
     -------
     coadd_data : dict
@@ -168,13 +175,16 @@ def make_coadd(
 
     for iexp, exp in enumerate(get_pbar(exps)):
 
-        warp, noise_warp, psf_warp, mfrac_warp, this_exp_info = make_warps(
-            exp=exp, coadd_wcs=coadd_wcs, coadd_bbox=coadd_bbox,
-            psf_dims=psf_dims, rng=rng, remove_poisson=remove_poisson,
-            max_maskfrac=max_maskfrac,
-        )
-        if this_exp_info['exp_id'] == -9999:
-            this_exp_info['exp_id'] = iexp
+        if is_warps:
+            warp, noise_warp, psf_warp, mfrac_warp, this_exp_info = load_warps(exp)
+        else:
+            warp, noise_warp, psf_warp, mfrac_warp, this_exp_info = make_warps(
+                exp=exp, coadd_wcs=coadd_wcs, coadd_bbox=coadd_bbox,
+                psf_dims=psf_dims, rng=rng, remove_poisson=remove_poisson,
+                max_maskfrac=max_maskfrac,
+            )
+            if this_exp_info['exp_id'] == -9999:
+                this_exp_info['exp_id'] = iexp
 
         exp_infos.append(this_exp_info)
 
@@ -431,7 +441,7 @@ def make_warps(
 
     Returns
     -------
-    warp, noise_warp, psf_warp, mfrac_warp, medvar, exp_info
+    warp, noise_warp, psf_warp, mfrac_warp, exp_info
 
     TODO
     ----
@@ -558,6 +568,20 @@ def write_warps(
     info: array
         info struct
     other_arguments_here: to be added
+    """
+    raise NotImplementedError('implement write_warps')
+
+
+def load_warps(deferred, other_arguments_here):
+    """
+    Load warps from disk
+
+    deferred: DeferredDatasetHandle
+        The handle from which to load data
+
+    Returns
+    --------
+    warp, noise_warp, psf_warp, mfrac_warp, exp_info
     """
     raise NotImplementedError('implement write_warps')
 

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -466,7 +466,7 @@ def _get_default_mfrac_warper():
 
 def make_warps(
     exp, coadd_wcs, coadd_bbox, rng, remove_poisson,
-    warper=None, mfrac_warper=None,
+    warper=None, mfrac_warper=None, verify=True,
 ):
     """
     make warps from the input exposure, including warps for the PSF, noise
@@ -491,6 +491,8 @@ def make_warps(
         The warper to use for the image, noise, and psf
     mfrac_warper: afw_math.Warper, optional
         The warper to use for the masked fraction
+    verify: bool, optional
+        If True, verify that the warps completely overlap the cell region.
 
     Returns
     -------
@@ -518,7 +520,7 @@ def make_warps(
     # stamp size for input and output psf and just zero out wherever there is
     # no data
 
-    verifys = [True, True, True]
+    verifys = [verify]*3
 
     LOG.info('warping and adding exposures')
 

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -53,7 +53,7 @@ def make_coadd_obs(
         The dimensions of the psf
     rng: np.random.RandomState
         The random number generator for making noise images
-    remove_poisson: bool
+    remove_poisson: bool, optional
         If True, remove the poisson noise from the variance
         estimate.
     max_maskfrac: float
@@ -116,11 +116,11 @@ def make_coadd(
     remove_poisson: bool
         If True, remove the poisson noise from the variance
         estimate.
-    max_maskfrac: float
+    max_maskfrac: float, optional
         Maximum allowed masked fraction.  Images masked more than
         this will not be included in the coadd.  Must be in range
         [0, 1]
-    is_warps: bool
+    is_warps: bool, optional
         If set to True the input exps are actually handles for a data set, from
         which the warps and info can be loaded
     Returns

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -225,7 +225,8 @@ def make_coadd(
         medvar = noise_warp.variance.array[0, 0]
         noise_warp.variance.array[:, :] = warp.variance.array[:, :]
 
-        psf_warp = warp_psf(psf=psf, wcs=wcs, coadd_wcs=coadd_wcs, coadd_bbox=coadd_bbox,
+        psf_warp = warp_psf(psf=psf, wcs=wcs, coadd_wcs=coadd_wcs,
+                            coadd_bbox=coadd_bbox,
                             psf_dims=psf_dims, var=medvar, filter_label=filter_label)
 
         warps = [warp, noise_warp, psf_warp, mfrac_warp]
@@ -604,7 +605,8 @@ def warp_exposures(
     return warp, noise_warp, mfrac_warp, exp_info
 
 
-def warp_psf(psf, wcs, coadd_wcs, coadd_bbox, psf_dims, var=1.0, warper=None, filter_label=None):
+def warp_psf(psf, wcs, coadd_wcs, coadd_bbox, psf_dims,
+             var=1.0, warper=None, filter_label=None):
     """Warp a PSF object to the coadd WCS and bounding box.and
 
     psf: `lsst.afw.detection.Psf`
@@ -1062,6 +1064,7 @@ def get_median_var(exp, remove_poisson):
         var = np.median(variance[use])
 
     return var
+
 
 def get_noise_exp(exp, rng, remove_poisson):
     """

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -192,7 +192,7 @@ def make_coadd(
         if is_warps:
             warp, noise_warp, mfrac_warp, this_exp_info = load_warps(exp)
         else:
-            warp, noise_warp, mfrac_warp, this_exp_info = make_warps(
+            warp, noise_warp, mfrac_warp, this_exp_info = warp_exposures(
                 exp=exp, coadd_wcs=coadd_wcs, coadd_bbox=coadd_bbox,
                 rng=rng, remove_poisson=remove_poisson,
             )
@@ -464,13 +464,12 @@ def _get_default_mfrac_warper():
     return mfrac_warper
 
 
-def make_warps(
+def warp_exposures(
     exp, coadd_wcs, coadd_bbox, rng, remove_poisson,
     warper=None, mfrac_warper=None, verify=True,
 ):
     """
-    make warps from the input exposure, including warps for the PSF, noise
-    images and masked fraction
+    Warps the input exposures, noise image and masked fraction
 
     This is the entry point to the package from the LSST Pipetask.
 

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -419,10 +419,12 @@ def make_warps(
     make warps from the input exposure, including warps for the PSF, noise
     images and masked fraction
 
+    This is the entry point to the package from the LSST Pipetask.
+
     Parameters
     ----------
     exp: ExposureF or DeferredDatasetHandle
-        Either a list of exposures or a list of DeferredDatasetHandle
+        Either an Exposure or a corresponding DeferredDatasetHandle
     coadd_wcs: DM wcs object
         The target wcs
     coadd_bbox: geom.Box2I

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -556,31 +556,6 @@ def make_warps(
     return warp, noise_warp, psf_warp, mfrac_warp, exp_info
 
 
-def write_warps(
-    warp, noise_warp, psf_warp, mfrac_warp, info, other_arguments_here,
-):
-    """
-    Write warps to disk
-
-    TODO:
-        1. Implement writing
-        2. Figure out how to get filename etc.
-
-    warp: ExposureF
-        The image warp
-    noise_warp: ExposureF
-        The noise image warp
-    psf_warp: ExposureF
-        The psf image warp
-    mfrac_warp: ExposureF
-        mfrac warp
-    info: array
-        info struct
-    other_arguments_here: to be added
-    """
-    raise NotImplementedError('implement write_warps')
-
-
 def load_warps(deferred, other_arguments_here):
     """
     Load warps from disk

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -414,6 +414,7 @@ def make_coadd_old(
 
 def make_warps(
     exp, coadd_wcs, coadd_bbox, psf_dims, rng, remove_poisson, max_maskfrac,
+    warper=None, mfrac_warper=None,
 ):
     """
     make warps from the input exposure, including warps for the PSF, noise
@@ -440,6 +441,10 @@ def make_warps(
         Maximum allowed masked fraction.  Images masked more than
         this will not be included in the coadd.  Must be in range
         [0, 1]
+    warper: afw_math.Warper
+        The warper to use for the image, noise, and psf
+    mfrac_warper: afw_math.Warper
+        The warper to use for the masked fraction
 
     Returns
     -------
@@ -464,13 +469,15 @@ def make_warps(
 
     # can re-use the warper for each coadd type except the mfrac where we use
     # linear
-    warp_config = afw_math.Warper.ConfigClass()
-    warp_config.warpingKernelName = DEFAULT_INTERP
-    warper = afw_math.Warper.fromConfig(warp_config)
+    if warper is None:
+        warp_config = afw_math.Warper.ConfigClass()
+        warp_config.warpingKernelName = DEFAULT_INTERP
+        warper = afw_math.Warper.fromConfig(warp_config)
 
-    warp_config = afw_math.Warper.ConfigClass()
-    warp_config.warpingKernelName = "bilinear"
-    mfrac_warper = afw_math.Warper.fromConfig(warp_config)
+    if mfrac_warper is None:
+        warp_config = afw_math.Warper.ConfigClass()
+        warp_config.warpingKernelName = "bilinear"
+        mfrac_warper = afw_math.Warper.fromConfig(warp_config)
 
     # will zip these with the exposures to warp and add
     wcss = [coadd_wcs, coadd_wcs, coadd_psf_wcs, coadd_wcs]

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -417,6 +417,34 @@ def make_coadd_old(
     return result
 
 
+def _get_default_image_warper():
+    """Get the default warper instances for warping images (and PSFs).
+
+    Returns
+    -------
+    warper: afw_math.Warper
+        Warper instance for warping images.
+    """
+    warp_config = afw_math.Warper.ConfigClass()
+    warp_config.warpingKernelName = DEFAULT_INTERP
+    warper = afw_math.Warper.fromConfig(warp_config)
+
+    return warper
+
+def _get_default_mfrac_warper():
+    """Get the default warper instances for warping masked fractions.
+
+    Returns
+    -------
+    mfrac_warper: afw_math.Warper
+        Warper instance for warping masked fractions.
+    """
+    warp_config = afw_math.Warper.ConfigClass()
+    warp_config.warpingKernelName = "bilinear"
+    mfrac_warper = afw_math.Warper.fromConfig(warp_config)
+
+    return mfrac_warper
+
 def make_warps(
     exp, coadd_wcs, coadd_bbox, psf_dims, rng, remove_poisson,
     warper=None, mfrac_warper=None,
@@ -471,14 +499,10 @@ def make_warps(
     # can re-use the warper for each coadd type except the mfrac where we use
     # linear
     if warper is None:
-        warp_config = afw_math.Warper.ConfigClass()
-        warp_config.warpingKernelName = DEFAULT_INTERP
-        warper = afw_math.Warper.fromConfig(warp_config)
+        warper = _get_default_image_warper()
 
     if mfrac_warper is None:
-        warp_config = afw_math.Warper.ConfigClass()
-        warp_config.warpingKernelName = "bilinear"
-        mfrac_warper = afw_math.Warper.fromConfig(warp_config)
+        mfrac_warper = _get_default_mfrac_warper()
 
     # will zip these with the exposures to warp and add
     wcss = [coadd_wcs, coadd_wcs, coadd_psf_wcs, coadd_wcs]

--- a/descwl_coadd/exceptions.py
+++ b/descwl_coadd/exceptions.py
@@ -9,3 +9,16 @@ class WarpBoundaryError(Exception):
 
     def __str__(self):
         return repr(self.value)
+
+
+class HighMaskedFrac(Exception):
+    """
+    masked fraction too high
+    """
+
+    def __init__(self, value):
+        super().__init__(value)
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)

--- a/descwl_coadd/tests/test_coadd.py
+++ b/descwl_coadd/tests/test_coadd.py
@@ -8,6 +8,7 @@ from descwl_shear_sims.sim import make_sim, get_se_dim
 from descwl_shear_sims.psfs import make_fixed_psf, make_ps_psf
 from descwl_shear_sims.stars import StarCatalog
 
+from descwl_coadd.coadd import get_bad_mask, get_median_var, warp_exposures, warp_psf
 from descwl_coadd.coadd import make_coadd_obs, make_coadd, make_coadd_old
 from descwl_coadd.procflags import WARP_BOUNDARY
 from descwl_shear_sims.galaxies import make_galaxy_catalog
@@ -381,6 +382,84 @@ def test_new_coadds():
     assert np.all(
         cdnew['coadd_mfrac_exp'].image.array == cdold['coadd_mfrac_exp'].image.array
     )
+
+
+@pytest.mark.parametrize('dither', [False, True])
+@pytest.mark.parametrize('rotate', [False, True])
+def test_warped_exposures(dither, rotate):
+    """Test that the warped exposure is same as a coadd with one input."""
+
+    epochs_per_band = 1
+    noise_seed = 9813
+
+    rng = np.random.RandomState(1234)
+    sim_data = _make_sim(
+        rng=rng,
+        psf_type='gauss',
+        bands=['i'],
+        coadd_dim=101,
+        psf_dim=51,
+        dither=dither,
+        rotate=rotate,
+        epochs_per_band=epochs_per_band,
+    )
+
+    exp = sim_data['band_data']['i'][0]
+    medvar = get_median_var(exp, False)
+    rng = np.random.RandomState(noise_seed)
+    warp, noise_warp, mfrac_warp, _ = warp_exposures(
+        exp=exp,
+        coadd_wcs=sim_data['coadd_wcs'],
+        coadd_bbox=sim_data['coadd_bbox'],
+        rng=rng,
+        remove_poisson=False,  # no object poisson noise in sims
+    )
+
+    _, maskfrac1 = get_bad_mask(exp)
+    _, maskfrac2 = get_bad_mask(warp)
+    # This is a trivial test of the maskfrac calculation.
+    assert maskfrac1 == maskfrac2
+
+    psf_warp = warp_psf(psf=exp.getPsf(), wcs=exp.getWcs(),
+                        coadd_wcs=sim_data['coadd_wcs'],
+                        coadd_bbox=sim_data['coadd_bbox'],
+                        psf_dims=sim_data['psf_dims'],
+                        var=medvar, filter_label=exp.getFilter())
+
+    for make_coadd_function in (make_coadd, make_coadd_old,):
+        rng = np.random.RandomState(noise_seed)
+        coadd_dict = make_coadd_function(
+            exps=sim_data['band_data']['i'],
+            coadd_wcs=sim_data['coadd_wcs'],
+            coadd_bbox=sim_data['coadd_bbox'],
+            psf_dims=sim_data['psf_dims'],
+            rng=rng,
+            remove_poisson=False,  # no object poisson noise in sims
+        )
+
+        np.testing.assert_array_equal(
+            coadd_dict['coadd_exp'].image.array,
+            warp.image.array
+        )
+        np.testing.assert_array_equal(
+            coadd_dict['coadd_noise_exp'].image.array,
+            noise_warp.image.array
+        )
+        np.testing.assert_array_equal(
+            coadd_dict['coadd_mfrac_exp'].image.array,
+            mfrac_warp.image.array
+        )
+
+        # Handling of NaNs is not done on the output from warp_psf
+        # and needs special handling.
+        assert (np.nansum(coadd_dict['coadd_psf_exp'].image.array)
+                == np.nansum(psf_warp.image.array))
+
+        use = ~np.isnan(psf_warp.image.array)
+        np.testing.assert_array_equal(
+            coadd_dict['coadd_psf_exp'].image.array[use],
+            psf_warp.image.array[use]
+        )
 
 
 @pytest.mark.skipif('CATSIM_DIR' not in os.environ,

--- a/descwl_coadd/tests/test_coadd.py
+++ b/descwl_coadd/tests/test_coadd.py
@@ -2,12 +2,13 @@ import sys
 import os
 import pytest
 import numpy as np
+import esutil as eu
 
 from descwl_shear_sims.sim import make_sim, get_se_dim
 from descwl_shear_sims.psfs import make_fixed_psf, make_ps_psf
 from descwl_shear_sims.stars import StarCatalog
 
-from descwl_coadd.coadd import make_coadd_obs, make_coadd
+from descwl_coadd.coadd import make_coadd_obs, make_coadd, make_coadd_old
 from descwl_coadd.procflags import WARP_BOUNDARY
 from descwl_shear_sims.galaxies import make_galaxy_catalog
 import logging
@@ -322,6 +323,64 @@ def test_coadds_not_used():
     wbad, = np.where(exp_info['flags'] != 0)
     assert wbad.size == 1
     assert wbad[0] == 1
+
+
+def test_new_coadds():
+    seed = 9312
+
+    for coadd_type in ('old', 'new'):
+        rng = np.random.RandomState(seed)
+
+        epochs_per_band = 3
+        sim_data = _make_sim(
+            rng=rng,
+            psf_type='gauss',
+            bands=['i'],
+            coadd_dim=101,
+            psf_dim=51,
+            epochs_per_band=epochs_per_band,
+        )
+
+        # TODO we don't have getId() yet, so assuming the first one is index 0 etc.
+        # for now
+        exps = sim_data['band_data']['i']
+        exp = exps[1]
+        flagval = exp.mask.getPlaneBitMask('BAD')
+
+        exp.mask.array[:, :] = flagval
+
+        if coadd_type == 'new':
+            function = make_coadd
+        else:
+            function = make_coadd_old
+
+        coadd_dict = function(
+            exps=exps,
+            coadd_wcs=sim_data['coadd_wcs'],
+            coadd_bbox=sim_data['coadd_bbox'],
+            psf_dims=sim_data['psf_dims'],
+            rng=rng,
+            remove_poisson=False,  # no object poisson noise in sims
+        )
+        if coadd_type == 'new':
+            cdnew = coadd_dict
+        else:
+            cdold = coadd_dict
+
+    assert cdnew['nkept'] == cdold['nkept']
+    assert eu.numpy_util.compare_arrays(cdnew['exp_info'], cdold['exp_info'])
+    assert np.all(
+        cdnew['coadd_exp'].image.array == cdold['coadd_exp'].image.array
+    )
+    assert np.all(
+        cdnew['coadd_noise_exp'].image.array == cdold['coadd_noise_exp'].image.array
+    )
+    assert np.all(
+        cdnew['coadd_psf_exp'].image.array == cdold['coadd_psf_exp'].image.array
+    )
+    assert np.all(
+        cdnew['coadd_mfrac_exp'].image.array == cdold['coadd_mfrac_exp'].image.array
+    )
 
 
 @pytest.mark.skipif('CATSIM_DIR' not in os.environ,

--- a/descwl_coadd/tests/test_coadd_correct.py
+++ b/descwl_coadd/tests/test_coadd_correct.py
@@ -25,7 +25,7 @@ def make_exp(gsimage, bmask, noise, galsim_wcs, galsim_psf, psf_dim):
 
     exp = afw_image.ExposureF(masked_image)
     filter_label = afw_image.FilterLabel(band='i', physical='i')
-    exp.setFilterLabel(filter_label)
+    exp.setFilter(filter_label)
 
     exp.setPsf(dm_psf)
     exp.setWcs(dm_wcs)


### PR DESCRIPTION
This code refactors the coadding so that warping happens in a new function `make_warps`.

This code generates the warps and info from an exposure object.

This function can be used by an external `Task` to generate warps and write them.  I put in a stub `write_warps` that can be filled in for this purpose.

If warps will be saved to disk and loaded later, we need to support that in the `make_coadd` code.  There is a new option `is_warps` that tells it to use the code `load_warps` to get the data from disk, assuming the inputs are deferred data sets for each warp rather than for exps.

There is another stubb that needs to be filled in, `load_warps`

@arunkannawadi 


I copied the old `make_coadd` to `make_coadd_old` and added tests ensuring the results are the same.  When the write/load features are added we should also add tests ensuring results are the same.