### PR TITLE
Refactor so that interpolator can be sent

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,14 +25,13 @@ jobs:
           channel-priority: strict
           show-channel-urls: true
           miniforge-version: latest
-          miniforge-variant: Miniforge
 
       - name: Install special dependencies with conda and pip
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
 
-          conda install -q stackvana=0
+          conda install -q stackvana
 
           conda install -q \
             flake8 \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,16 +25,16 @@ jobs:
           channel-priority: strict
           show-channel-urls: true
           miniforge-version: latest
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge
 
-      - name: Install special dependencies with mamba and pip
+      - name: Install special dependencies with conda and pip
         shell: bash -l {0}
         run: |
-          mamba config --set always_yes yes
+          conda config --set always_yes yes
 
-          mamba install -q stackvana=0
+          conda install -q stackvana=0
 
-          mamba install -q \
+          conda install -q \
             flake8 \
             pytest \
             numpy \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     name: tests
     strategy:
       matrix:
-        pyver: ["3.10", "3.11"]
+        pyver: ["3.11"]
 
     runs-on: "ubuntu-latest"
 

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -688,7 +688,6 @@ def warp_psf(psf, wcs, coadd_wcs, coadd_bbox, psf_dims,
             var=var,
             filter_label=filter_label)
 
-    LOG.info('warping PSF')
     psf_warp, = _get_warps_for_exp([psf_exp], wcss, bboxes, warpers, [False])
 
     return psf_warp

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -575,8 +575,6 @@ def warp_exposures(
 
     verifys = [verify]*3
 
-    LOG.info('warping and adding exposures')
-
     if isinstance(exp, DeferredDatasetHandle):
         expobj = exp.get()
     else:

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -137,7 +137,7 @@ def make_coadd(
         an exposure info table. If False, ``exps`` is a list of exposures.
     interpolator: interpolator object, optional
         An object or function used to interpolate pixels.
-        Must be callable as interpolator(exposure)
+        Must be usable as interpolator.run(exposure)
     warper: afw_math.Warper, optional
         The warper to use for the PSF, and for image and noise if ``is_warps``
         is False.
@@ -537,7 +537,7 @@ def warp_exposures(
         estimate.
     interpolator: interpolator object, optional
         An object or function used to interpolate pixels.
-        Must be callable as interpolator(exposure)
+        Must be runable as interpolator.run(exposure)
     warper: afw_math.Warper, optional
         The warper to use for the image, noise, and psf
     mfrac_warper: afw_math.Warper, optional
@@ -601,8 +601,8 @@ def warp_exposures(
 
         if 0 < maskfrac < 1:
             # This modifies the image internally and sets INTRP in mask
-            interpolator(expobj)
-            interpolator(noise_exp)
+            interpolator.run(expobj)
+            interpolator.run(noise_exp)
 
             # interp_nocheck(exp=expobj, noise_exp=noise_exp, bad_msk=bad_msk)
 

--- a/descwl_coadd/coadd_nowarp.py
+++ b/descwl_coadd/coadd_nowarp.py
@@ -129,8 +129,8 @@ def make_coadd_nowarp(exp, psf_dims, rng, remove_poisson, interpolator=None):
 
         if maskfrac > 0:
             # images modified internally
-            interpolator(exp)
-            interpolator(noise_exp)
+            interpolator.run(exp)
+            interpolator.run(noise_exp)
 
         cen, cen_skypos = get_coadd_center(
             coadd_wcs=exp.getWcs(), coadd_bbox=exp.getBBox(),

--- a/descwl_coadd/defaults.py
+++ b/descwl_coadd/defaults.py
@@ -16,3 +16,6 @@ BOUNDARY_SIZE = 3
 # included in the coadd
 # TODO make configurable
 MAX_MASKFRAC = 0.9
+
+# used for getting good pixels around a set of bad pixels
+DEFAULT_GOOD_PIXEL_BUFF = 4

--- a/descwl_coadd/interp.py
+++ b/descwl_coadd/interp.py
@@ -141,14 +141,13 @@ class CTInterpolator(object):
     This conforms to the interface required for the interpolator
     sent to descwl_coadd.coadd.warp_exposures
 
-    This is a "functor" meaning the object can be called
-        interpolator(exposure)
+        interpolator.run(exposure)
     """
     def __init__(self, bad_mask_planes=FLAGS2INTERP, buff=DEFAULT_GOOD_PIXEL_BUFF):
         self.bad_mask_planes = bad_mask_planes
         self.buff = buff
 
-    def __call__(self, exp):
+    def run(self, exp):
         """
         Interpolate the exposure in place
 

--- a/descwl_coadd/tests/test_coadd_and_psf_coadd_agree.py
+++ b/descwl_coadd/tests/test_coadd_and_psf_coadd_agree.py
@@ -5,6 +5,7 @@ import galsim
 from descwl_shear_sims.sim import make_sim
 from descwl_shear_sims.psfs import make_fixed_psf
 from descwl_shear_sims.surveys import get_survey
+from descwl_shear_sims.layout import Layout
 
 from descwl_coadd.coadd import make_coadd_obs
 import logging
@@ -26,6 +27,7 @@ class OneStarCatalog(object):
     def __init__(self, coadd_dim, mag=17):
         self.gal_type = 'fixed'
         self.mag = mag
+        self.layout = 'grid'
 
     def __len__(self):
         return 1

--- a/descwl_coadd/tests/test_coadd_and_psf_coadd_agree.py
+++ b/descwl_coadd/tests/test_coadd_and_psf_coadd_agree.py
@@ -5,8 +5,6 @@ import galsim
 from descwl_shear_sims.sim import make_sim
 from descwl_shear_sims.psfs import make_fixed_psf
 from descwl_shear_sims.surveys import get_survey
-from descwl_shear_sims.layout import Layout
-
 from descwl_coadd.coadd import make_coadd_obs
 import logging
 


### PR DESCRIPTION

    the interpolator must conform to a simple interface,
    it must be callable as interpolator(exposure)
    
    It is expected to interpolate in place and set the INTRP
    bit
    
    Implement the default as interpt.CTInterpolator which
    just wraps our current function
    
    This will allow testing different interpolators that
    conform to the interface
