### PR TITLE
Log individual flag in verify_warp

### DIFF
--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -782,9 +782,6 @@ def verify_warp(exp):
         for flagname in tocheck:
             flag = exp.mask.getPlaneBitMask(flagname)
             w = np.where(exp.mask.array & flag != 0)
-            print(f"Flagname: {flagname}")
-            print(f"Flag: {flag}")
-            print(f"size: {w[0].size}")
             if w[0].size > 0:
                 message += [
                     f'{w[0].size} pixels with {flagname}'

--- a/descwl_coadd/coadd.py
+++ b/descwl_coadd/coadd.py
@@ -780,13 +780,18 @@ def verify_warp(exp):
         # give fine grained feedback on what happened
         message = []
         for flagname in tocheck:
-            w = np.where(exp.mask.array & all_flags != 0)
+            flag = exp.mask.getPlaneBitMask(flagname)
+            w = np.where(exp.mask.array & flag != 0)
+            print(f"Flagname: {flagname}")
+            print(f"Flag: {flag}")
+            print(f"size: {w[0].size}")
             if w[0].size > 0:
                 message += [
                     f'{w[0].size} pixels with {flagname}'
                 ]
-            message = ' and '.join(message)
-            raise WarpBoundaryError(message)
+
+        message = ' and '.join(message)
+        raise WarpBoundaryError(message)
 
         if False:
             vis.show_image_and_mask(exp)


### PR DESCRIPTION
Currently, `verify_warp` always logs the first flag name with the total number of flagged pixels, which might be confusing if there are more than one flag. After this PR the code should correctly log the right flag name and right number of flagged pixels joined by and.

Should I write a test for this, given it's a bug in the log message? Thanks!