### PR TITLE
Update return of one star catalog to agree with descwlshearsims

### DIFF
--- a/descwl_coadd/tests/test_coadd_and_psf_coadd_agree.py
+++ b/descwl_coadd/tests/test_coadd_and_psf_coadd_agree.py
@@ -61,7 +61,6 @@ class OneStarCatalog(object):
         }
 
 
-
 def _make_one_star_sim(
     rng, psf_type='gauss',
     epochs_per_band=3,

--- a/descwl_coadd/tests/test_coadd_and_psf_coadd_agree.py
+++ b/descwl_coadd/tests/test_coadd_and_psf_coadd_agree.py
@@ -42,7 +42,7 @@ class OneStarCatalog(object):
 
         Returns
         -------
-        [galsim objects], [shifts]
+        [galsim objects], [shifts], [redshifts], [indexes]
         """
 
         flux = survey.get_flux(self.mag)
@@ -51,7 +51,16 @@ class OneStarCatalog(object):
         shifts = [galsim.PositionD(0, 0)]
 
         redshifts = None
-        return objlist, shifts, redshifts
+        indexes = None
+
+        
+        return {
+            "objlist": objlist,
+            "shifts": shifts,
+            "redshifts": redshifts,
+            "indexes": indexes,
+        }
+
 
 
 def _make_one_star_sim(

--- a/descwl_coadd/tests/test_coadd_and_psf_coadd_agree.py
+++ b/descwl_coadd/tests/test_coadd_and_psf_coadd_agree.py
@@ -53,7 +53,6 @@ class OneStarCatalog(object):
         redshifts = None
         indexes = None
 
-        
         return {
             "objlist": objlist,
             "shifts": shifts,


### PR DESCRIPTION
There is a change in the API of `descwl-shear-sims` that is causing `test_coadd_and_psf_coadd_agree.py` to fail. This PR updates the return of `get_objectlist` to keep up with the change in `descwl-shear-sims`. 