### PR TITLE
Get median variance from noise warp correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # descwl_coadd
-[![Build Status](https://travis-ci.com/LSSTDESC/descwl_coadd.svg?branch=master)](https://travis-ci.com/LSSTDESC/descwl_coadd)
+[![Build Status](https://github.com/LSSTDESC/descwl_coadd/actions/workflows/test.yaml/badge.svg)](https://github.com/LSSTDESC/descwl_coadd/actions/workflows/test.yaml)
 
 Tools for coadding using the LSST DM software stack
 


### PR DESCRIPTION
Since a warp can have multiple detectors, the variance plane of the `noise_warp`, which is used to carry around the value of the median variance value (`medvar`), is only piecewise constant. I found this bug while working on the unit tests in the `descwl-coadd-task` repo, but this needs to be patched first.